### PR TITLE
bugfix: xsd datatype -> java classes was assuming xsd -> stark is 1:1

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(defproject stardog-clj "6.0.1"
+(defproject stardog-clj "6.0.2"
   :description "Stardog-clj: Clojure bindings for Stardog"
   :url "http://stardog.com"
   :license {:name "Apache License"

--- a/src/stardog/values.clj
+++ b/src/stardog/values.clj
@@ -23,13 +23,13 @@
 (defmulti typed-value (fn [^Literal v] (.. v datatype toString)))
 
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#integer"
-  [^Literal v] (.intValue v))
+  [^Literal v] (Literal/intValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#int"
-  [^Literal v] (.intValue v))
+  [^Literal v] (Literal/intValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#boolean"
-  [^Literal v] (.booleanValue v))
+  [^Literal v] (Literal/booleanValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#byte"
-  [^Literal v] (.byteValue v))
+  [^Literal v] (Literal/byteValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#dateTime"
   [^Literal v] (.. v calendarValue toGregorianCalendar getTime))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#time"
@@ -47,15 +47,15 @@
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#gDay"
   [^Literal v] (.. v calendarValue toGregorianCalendar getTime))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#decimal"
-  [^Literal v] (.decimalValue v))
+  [^Literal v] (Literal/decimalValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#double"
-  [^Literal v] (.doubleValue v))
+  [^Literal v] (Literal/doubleValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#float"
-  [^Literal v] (.floatValue v))
+  [^Literal v] (Literal/floatValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#long"
-  [^Literal v] (.longValue v))
+  [^Literal v] (Literal/longValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#short"
-  [^Literal v] (.shortValue v))
+  [^Literal v] (Literal/shortValue v))
 (defmethod typed-value "http://www.w3.org/2001/XMLSchema#string"
   [^Literal v] (.label v))
 (defmethod typed-value :default


### PR DESCRIPTION
XSD datatypes -> stark classes is one -> many, so the strategy of using a specific stark class's conversion method is a bad one. Instead this uses stark's more generic literal conversion methods which each cover a bunch of impl classes.
- [ ] tests