### PR TITLE
Update to Stardog 6.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stardog-clj - Clojure language bindings to use to develop apps with the [Stardog
 To use stardog-clj, follow these simple steps:
 
 1. Download [Stardog](http://stardog.com), and unzip it
-2. In your application, add the stardog-clj dependency to your project.clj file, or equivalent build tool.  For example, `[stardog-clj "5.0.0-RC1"]`
+2. In your application, add the stardog-clj dependency to your project.clj file, or equivalent build tool.  For example, `[stardog-clj "6.2.1"]`
 3. In your application, create a database specification `(create-db-spec database "http://localhost:5820/" "admin" "admin" true)`
 4. You can use this specification to make a connection pool with `(make-datasource spec)`
 5. Use `(with-connection-pool [conn datasource])` to start using the connection pool
@@ -99,7 +99,7 @@ The test suite does run with the assumption there is a Stardog database server r
 
 ## License
 
-Copyright 2014, 2015, 2016, 2017 Stardog Union
+Copyright 2014, 2015, 2016, 2017, 2018, 2019 Stardog Union
 
 Copyright 2014 Paula Gearon
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-;; Copyright (C) 2016-2018 Stardog Union
+;; Copyright (C) 2016-2019 Stardog Union
 ;; Copyright (C) 2014-2015 Clark & Parsia
 ;; Copyright (C) 2014 Paula Gearon
 ;;
@@ -13,15 +13,18 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(defproject stardog-clj "6.0.2"
+(require 'cemerick.pomegranate.aether)
+(cemerick.pomegranate.aether/register-wagon-factory!
+ "http" #(org.apache.maven.wagon.providers.http.HttpWagon.))
+(defproject stardog-clj "6.2.1"
   :description "Stardog-clj: Clojure bindings for Stardog"
   :url "http://stardog.com"
   :license {:name "Apache License"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [com.complexible.stardog/client-http "6.0.1" :extension "pom"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [com.complexible.stardog/client-http "6.2.1" :extension "pom"]]
   :repositories [["stardog" "http://maven.stardog.com"]]
-  :plugins [[jonase/eastwood "0.0.2"]
-            [lein-midje "3.1.3"]]
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]
-                   :plugins [[lein-midje "3.1.3"]]}} )
+  :plugins [[jonase/eastwood "0.3.6"]
+            [lein-midje "3.2"]]
+  :profiles {:dev {:dependencies [[midje "1.9.9"]]
+                   :plugins [[lein-midje "3.2"]]}})


### PR DESCRIPTION
Part of preparation for deploying Cross System Search

* Updates Stardog dependency from 6.0.1 to 6.2.1 (we are upgrading stardog instances on NASA VMs to 6.2.1)
* Updates Clojure to 1.9
* Misc. dependency updates
* Copyright updates

Ran tests locally and all pass.