### PR TITLE
Bump stardog dependency to 7.4.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,16 +13,16 @@
 ;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ;; See the License for the specific language governing permissions and
 ;; limitations under the License.
-(defproject stardog-clj "7.4.0.1"
+(defproject stardog-clj "7.4.5"
   :description "Stardog-clj: Clojure bindings for Stardog"
   :url "http://stardog.com"
   :license {:name "Apache License"
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.10.1"]
-                 [com.complexible.stardog/client-http "7.4.0" :extension "pom"]
+                 [com.complexible.stardog/client-http "7.4.5" :extension "pom"]
                  [org.clojure/tools.logging "1.1.0"]
                  [ch.qos.logback/logback-classic "1.2.3"]]
   :repositories [["stardog" "https://maven.stardog.com"]]
-  :plugins [[jonase/eastwood "0.3.11"]]
+  :plugins [[jonase/eastwood "0.3.12"]]
   :profiles {:dev {:dependencies [[midje "1.9.9"]]
                    :plugins [[lein-midje "3.2.2"]]}})


### PR DESCRIPTION
Do we need a release for any interim version between 7.4.0 and 7.4.5? If so, we should do those first.